### PR TITLE
fix: add the @apollo/gateway dependency on the example, needed for IntrospectAndCompose

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@apollo/server": "^5.0.0",
     "@apollo/subgraph": "^2.11.2",
+    "@apollo/gateway": "^2.11.2",
     "@profusion/apollo-federation-node-gateway": "^4.0.2",
     "graphql": "^16.11.0",
     "graphql-tag": "^2.12.6"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -15,6 +15,14 @@
     "@apollo/federation-internals" "2.11.2"
     "@apollo/query-graphs" "2.11.2"
 
+"@apollo/composition@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@apollo/composition/-/composition-2.12.0.tgz#606470ab4a510cd428918b7c0476c36cfb5ff64f"
+  integrity sha512-Gf6SWzfFAUyxj+dIBImraRsDDigvdO0zkoq0tnYSwqzHUO9dHeztkLf2+4VJPHnwJ06UqLOLrZARMB7pzb/UBg==
+  dependencies:
+    "@apollo/federation-internals" "2.12.0"
+    "@apollo/query-graphs" "2.12.0"
+
 "@apollo/federation-internals@2.11.2", "@apollo/federation-internals@^2.5.1":
   version "2.11.2"
   resolved "https://registry.yarnpkg.com/@apollo/federation-internals/-/federation-internals-2.11.2.tgz#ab0df7d427935c6e3323c0083f866d659f206b5f"
@@ -24,6 +32,40 @@
     chalk "^4.1.0"
     js-levenshtein "^1.1.6"
     uuid "^9.0.0"
+
+"@apollo/federation-internals@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@apollo/federation-internals/-/federation-internals-2.12.0.tgz#8073774d1fa4266f550d51d231a9d58ae3e0184f"
+  integrity sha512-NCqKxZqTT9oFqRfq/yLcb8U5rzt+v00i5d5cFFadjdO61YwAUCD0W5JFDQzZsYzX7huuK/7N7JWqI897vAOeeQ==
+  dependencies:
+    "@types/uuid" "^9.0.0"
+    chalk "^4.1.0"
+    js-levenshtein "^1.1.6"
+    uuid "^9.0.0"
+
+"@apollo/gateway@^2.11.2":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@apollo/gateway/-/gateway-2.12.0.tgz#0aa960bbe745187fce3d40e14711f37119411301"
+  integrity sha512-L6n5qgaJSch/fHiU1LhYLqhiRwrNzvWP3sh8yhHbZeDw55KxUbzF9B69o1ic3ltKR0AO6i5lIejBVFimtauL6w==
+  dependencies:
+    "@apollo/composition" "2.12.0"
+    "@apollo/federation-internals" "2.12.0"
+    "@apollo/query-planner" "2.12.0"
+    "@apollo/server-gateway-interface" "^1.1.0"
+    "@apollo/usage-reporting-protobuf" "^4.1.0"
+    "@apollo/utils.createhash" "^2.0.0"
+    "@apollo/utils.fetcher" "^2.0.0"
+    "@apollo/utils.isnodelike" "^2.0.0"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+    "@apollo/utils.logger" "^2.0.0"
+    "@josephg/resolvable" "^1.0.1"
+    "@opentelemetry/api" "^1.0.1"
+    "@types/node-fetch" "^2.6.2"
+    async-retry "^1.3.3"
+    loglevel "^1.6.1"
+    make-fetch-happen "^11.0.0"
+    node-abort-controller "^3.0.1"
+    node-fetch "^2.6.7"
 
 "@apollo/gateway@^2.5.1":
   version "2.11.2"
@@ -77,6 +119,16 @@
     ts-graphviz "^1.5.4"
     uuid "^9.0.0"
 
+"@apollo/query-graphs@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@apollo/query-graphs/-/query-graphs-2.12.0.tgz#b06f22e0daa7be3a83fe701dd7c491cc15b4cbe8"
+  integrity sha512-4O8noHTpbwvAu0aYBfX7hTLw/FYjYGL2bFbmL/VXDDH46zd+oow0k3HAk3Jyq/i0AXobZ26Amne7cDB1IzyLEQ==
+  dependencies:
+    "@apollo/federation-internals" "2.12.0"
+    deep-equal "^2.0.5"
+    ts-graphviz "^1.5.4"
+    uuid "^9.0.0"
+
 "@apollo/query-planner@2.11.2":
   version "2.11.2"
   resolved "https://registry.yarnpkg.com/@apollo/query-planner/-/query-planner-2.11.2.tgz#cecaa39a937b6bad4450694db712a05ca340db19"
@@ -84,6 +136,18 @@
   dependencies:
     "@apollo/federation-internals" "2.11.2"
     "@apollo/query-graphs" "2.11.2"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+    chalk "^4.1.0"
+    deep-equal "^2.0.5"
+    pretty-format "^29.0.0"
+
+"@apollo/query-planner@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@apollo/query-planner/-/query-planner-2.12.0.tgz#08450b3ca9638d26a7575e2b73ace0b812fea803"
+  integrity sha512-lnO9cDS5+rNXus3T3woPB0QUtEq2BYnP3+IczUfBH2uc3xjOSss7a1yy/RAbb4GPMJH0gCqJKVAl+WUHe47qbQ==
+  dependencies:
+    "@apollo/federation-internals" "2.12.0"
+    "@apollo/query-graphs" "2.12.0"
     "@apollo/utils.keyvaluecache" "^2.1.0"
     chalk "^4.1.0"
     deep-equal "^2.0.5"


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->
Added the `@apollo/gateway` dependency needed for the gateway service. The example was not running without it.

## How to test it

<!-- Describe how the reviewers can test your feature. -->

1. Navigate to the example directory:
```shell
cd example
```
2. Install the dependencies:
```shell
yarn install
```
3. Run the posts and users services (in separate windows):
```shell
yarn ts-node src/services/users.ts
yarn ts-node src/services/posts.ts
``` 
4. Run the example gateway
```shell
yarn start
``` 
